### PR TITLE
2.0 qt updates - fixes phantomjs crashes in list view and compile errors

### DIFF
--- a/src/qt/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
+++ b/src/qt/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
@@ -738,7 +738,8 @@ _hb_coretext_shape (hb_shape_plan_t    *shape_plan,
     if (num_glyphs == 0)
       continue;
 
-    buffer->ensure (buffer->len + num_glyphs + (endWithPDF ? 1 : 0));
+    const long ensureCount = DIV_CEIL(sizeof(CGGlyph) + sizeof(CGPoint) + sizeof(CFIndex), sizeof(*scratch));
+    buffer->ensure (buffer->len + ensureCount * (num_glyphs + (endWithPDF ? 1 : 0)));
 
     scratch = buffer->get_scratch_buffer (&scratch_size);
 

--- a/src/qt/qtbase/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+++ b/src/qt/qtbase/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
@@ -124,7 +124,7 @@ static void cleanupCocoaApplicationDelegate()
     [dockMenu release];
     [qtMenuLoader release];
     if (reflectionDelegate) {
-        [NSApp setDelegate:reflectionDelegate];
+        [[NSApplication sharedApplication] setDelegate:reflectionDelegate];
         [reflectionDelegate release];
     }
     [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -163,6 +163,9 @@ static void cleanupCocoaApplicationDelegate()
 - (NSMenu *)applicationDockMenu:(NSApplication *)sender
 {
     Q_UNUSED(sender);
+    // Manually invoke the delegate's -menuWillOpen: method.
+    // See QTBUG-39604 (and its fix) for details.
+    [[dockMenu delegate] menuWillOpen:dockMenu];
     return [[dockMenu retain] autorelease];
 }
 
@@ -223,7 +226,14 @@ static void cleanupCocoaApplicationDelegate()
             // events while the event loop is still running.
             const QWindowList topLevels = QGuiApplication::topLevelWindows();
             for (int i = 0; i < topLevels.size(); ++i) {
-                QWindowSystemInterface::handleCloseEvent(topLevels.at(i));
+                QWindow *topLevelWindow = topLevels.at(i);
+                // Widgets have alreay received a CloseEvent from the QApplication
+                // QCloseEvent handler. (see canQuit above). Prevent running the
+                // CloseEvent logic twice, call close() directly.
+                if (topLevelWindow->inherits("QWidgetWindow"))
+                    topLevelWindow->close();
+                else
+                    QWindowSystemInterface::handleCloseEvent(topLevelWindow);
             }
             QWindowSystemInterface::flushWindowSystemEvents();
 
@@ -404,7 +414,7 @@ static void cleanupCocoaApplicationDelegate()
 {
     Q_UNUSED(replyEvent);
     NSString *urlString = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-    QWindowSystemInterface::handleFileOpenEvent(QCFString::toQString(urlString));
+    QWindowSystemInterface::handleFileOpenEvent(QUrl(QCFString::toQString(urlString)));
 }
 
 - (void)appleEventQuit:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent


### PR DESCRIPTION
Ticket #2232

PhantomJS crashed when trying to render the list view, reporting the following error:

phantom stderr: Assertion failed: (_consumed <= scratch_size), function _hb_coretext_shape, file src/hb-coretext.cc, line 764.

Changes to hb-coretext.cc fixed this problem.  Changes to cocoa file fixed compile errors in OSX Yosemite 10.10.2.  Both issues were caused by PhantomJS compiling with an old version of QT.  These changes update these files to QT version 5.4. 